### PR TITLE
Fix RegExp generation

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ class Eslint {
         : config.include
 
       config.test = Array.isArray(config.test)
-        ? (Regexp(RegExp(`\\.(${config.test.join('|')})$`)))
+        ? RegExp(`\\.(${config.test.join('|')})$`)
         : /\.(js|vue)$/
     }
 


### PR DESCRIPTION
Regexp (with lower case 'e') is going to cause a `ReferenceError: Regexp is not defined`.

Additionally I think we can simplify here with only one RegExp.